### PR TITLE
Make compatible with Windows OS

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
       shell: bash
       run: |
         python -m pip install --upgrade setuptools wheel pip setuptools-scm
-        pip install fugashi[unidic-lite] jaconv pytest hypothesis
+        pip install fugashi[unidic-lite] habachen pytest hypothesis
         pip install .
     - name: Run tests
       run: |

--- a/cutlet/cli.py
+++ b/cutlet/cli.py
@@ -2,12 +2,15 @@ from cutlet import Cutlet
 import fileinput
 import sys
 
-# Don't print an error on SIGPIPE
-from signal import signal, SIGPIPE, SIG_DFL
 
 def main():
-    signal(SIGPIPE, SIG_DFL) 
-    system = sys.argv[1] if len(sys.argv) > 1 else 'hepburn'
+    if sys.platform != "win32":
+        # Don't print an error on SIGPIPE
+        from signal import signal, SIGPIPE, SIG_DFL
+
+        signal(SIGPIPE, SIG_DFL)
+
+    system = sys.argv[1] if len(sys.argv) > 1 else "hepburn"
 
     katsu = Cutlet(system)
 

--- a/cutlet/cutlet.py
+++ b/cutlet/cutlet.py
@@ -1,6 +1,5 @@
 import fugashi
-import jaconv
-import mojimoji
+import habachen
 import unicodedata
 import re
 import pathlib
@@ -65,9 +64,9 @@ def normalize_text(text):
     # perform unicode normalization
     text = unicodedata.normalize('NFKC', text)
     # convert all full-width alphanum to half-width, since it can go out as-is
-    text = mojimoji.zen_to_han(text, kana=False)
+    text = habachen.zen_to_han(text, kana=False)
     # replace half-width katakana with full-width
-    text = mojimoji.han_to_zen(text, digit=False, ascii=False)
+    text = habachen.han_to_zen(text, digit=False, ascii=False)
     return text
 
 def load_exceptions():
@@ -318,7 +317,7 @@ class Cutlet:
             # Check character type using the values defined in char.def.
             # This is constant across unidic versions so far but not guaranteed.
             if word.char_type in (CHAR_HIRAGANA, CHAR_KATAKANA):
-                kana = jaconv.kata2hira(word.surface)
+                kana = habachen.to_hiragana(word.surface)
                 return self.map_kana(kana)
 
             # At this point this is an unknown word and not kana. Could be
@@ -348,7 +347,7 @@ class Cutlet:
             return word.feature.lemma.split('-')[-1]
         elif word.feature.kana:
             # for known words
-            kana = jaconv.kata2hira(word.feature.kana)
+            kana = habachen.to_hiragana(word.feature.kana)
             return self.map_kana(kana)
         else:
             # unclear when we would actually get here

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ attrs==23.1.0
 fugashi==1.2.1
 hypothesis==6.78.2
 iniconfig==2.0.0
-jaconv==0.3.4
-mojimoji==0.0.12
+habachen==0.5.0
 packaging==23.1
 pluggy==1.0.0
 pytest==7.3.2


### PR DESCRIPTION
- On windows, CLI no longer uses the environment-specific variable SIGPIPE.

- Use [habachen](https://github.com/Hizuru3/python-habachen) to convert texts